### PR TITLE
Fix: Add @classmethod decorator to API handlers

### DIFF
--- a/python/api/api_login.py
+++ b/python/api/api_login.py
@@ -5,8 +5,10 @@ from sqlalchemy.orm import Session
 import jwt, datetime, os
 
 class ApiLogin(ApiHandler):
-    def requires_auth(self): return False
-    def requires_csrf(self): return False
+    @classmethod
+    def requires_auth(cls): return False
+    @classmethod
+    def requires_csrf(cls): return False
     async def handle_request(self, request):
         data = request.get_json()
         email = data.get('email')

--- a/python/api/api_register.py
+++ b/python/api/api_register.py
@@ -4,8 +4,10 @@ from database import crud, schemas
 from sqlalchemy.orm import Session
 
 class ApiRegister(ApiHandler):
-    def requires_auth(self): return False
-    def requires_csrf(self): return False
+    @classmethod
+    def requires_auth(cls): return False
+    @classmethod
+    def requires_csrf(cls): return False
     async def handle_request(self, request):
         json_data = request.get_json()
         try:


### PR DESCRIPTION
This commit fixes a `TypeError` that occurred when starting the server. The `requires_auth` and `requires_csrf` methods in the `ApiLogin` and `ApiRegister` classes were missing the `@classmethod` decorator, which caused the application to crash on startup.

This commit adds the required decorators and changes the method signatures to use `cls` instead of `self`.